### PR TITLE
use the forked version of ElasticSearch module which handles newer AP…

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -8,6 +8,10 @@ mod 'puppetlabs/inifile',          '1.2.0'
 mod 'puppetlabs/apt',              '2.2.1'
 mod 'puppetlabs/java',             '1.4.3'
 
-mod 'elasticsearch/elasticsearch', '0.10.3'
 mod 'richardc/datacat',            '0.6.2'
+
+mod 'elasticsearch',
+  :git    => 'https://github.com/centriascolocation/puppet-elasticsearch.git',
+  :branch => 'fix_apt_module'
+
 


### PR DESCRIPTION
in order to test it with already provisioned boxes, make sure the module is fetched again. Therefore remove:

file: modules/.r10k_stamp
dir: modules/elasticsearch

After you have removed those, just provision your box(es) again as usual.
